### PR TITLE
active_hashへ移行

### DIFF
--- a/app/models/burden.rb
+++ b/app/models/burden.rb
@@ -1,0 +1,6 @@
+class Burden < ActiveHash::Base
+  self.data = [ 
+    {id: 1, name: '送料込み（出品者負担）'},
+    {id: 2, name: '着払い（購入者負担）'}
+  ]
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,10 @@
+class Condition < ActiveHash::Base
+  self.data = [
+    {id: 1, name: '新品、未使用'}, 
+    {id: 2, name: '未使用に近い'}, 
+    {id: 3, name: '目立った傷や汚れなし'}, 
+    {id: 4, name: 'やや傷や汚れあり'}, 
+    {id: 5, name: '傷や汚れあり'}, 
+    {id: 6, name: '全体的に状態が悪い'}, 
+  ]
+end

--- a/app/models/duration.rb
+++ b/app/models/duration.rb
@@ -1,0 +1,7 @@
+class Duration < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '1~2日で発送'}, 
+      {id: 2, name: '2~3日で発送'}, 
+      {id: 3, name: '3~4日で発送'}
+  ]
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,9 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
+  belongs_to_active_hash :condition
+  belongs_to_active_hash :burden
+  belongs_to_active_hash :duration
   has_many :images, dependent: :destroy
   belongs_to :user
   belongs_to :category
@@ -9,7 +12,7 @@ class Item < ApplicationRecord
     validates :name
     validates :price
     validates :discription
-    validates :condition
+    validates :condition_id
     validates :delivery_charge
     validates :prefecture_id
     validates :duration

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -32,14 +32,14 @@
         .in__main__show__condition
           商品の状態
           %span.required 必須
-        = f.select :condition, [["新品、未使用","新品、未使用"],["未使用に近い","未使用に近い"]],{prompt: "選択してください"},{ class: "in__main__show__form"}
+        = f.collection_select :condition_id, Condition.all, :id, :name,{prompt: "選択してください"},{ class: "in__main__show__form"}
       .in__main__ship
         .in__main__ship__title
           配送について
         .in__main__ship__charge
           配送料の負担
           %span.required 必須
-        = f.select :delivery_charge, [["送料込み(出品者負担)","送料込み"],["着払い","購入者負担"]],{prompt: "選択してください"},{ class: "in__main__ship__chargeForm"}
+        = f.collection_select :burden_id, Burden.all, :id, :name,{prompt: "選択してください"},{ class: "in__main__ship__chargeForm"}
         .in__main__ship__region
           発送元の地域
           %span.required 必須
@@ -47,7 +47,7 @@
         .in__main__ship__day
           発送までの日数
           %span.required 必須
-        = f.select :duration, [["1~2日で発送","1~2日で発送"],["2~3日で発送","2~3日で発送"],["4~7日で発送","4~7日で発送"]],{prompt: "選択してください"},{ class: "in__main__ship__form"}
+        = f.collection_select :duration_id, Duration.all, :id, :name,{prompt: "選択してください"},{ class: "in__main__ship__form"}
       .in__main__price
         .in__main__price__title
           価格（¥300〜9,999,999）


### PR DESCRIPTION
# what
発送までの日数、送料の負担、商品の状態をactive_hashに変更。変更に伴い、カラム名を変更
* duration → duration_id
* condition → condition_id
* delivery_charge → burden_id
# why
DBにデータとして保存しておくほど重要ではない、かつ、基本的に変更されないため

## 周知
便宜上delivery_chargeカラムをburden_idへと大幅に名前を変えました。これで今の段階で商品出品ページのフォームにおいてactive_hashにすべきところはすべて移行完了。今後もカテゴリーやブランドにおいて変更していく可能性があります