### PR TITLE
新規登録/ログイン画面修正

### DIFF
--- a/app/assets/stylesheets/devise/registrations/_new.scss
+++ b/app/assets/stylesheets/devise/registrations/_new.scss
@@ -58,7 +58,7 @@
         &__form{
           .user_information{
             height: 20px;
-            padding-top: 20px;
+            padding-top: 20px 0;
             h1{
               font-weight: bold;
               font-size: 16px;
@@ -191,23 +191,28 @@
               }
             }
           }
-          .move_next{
+          .address{
+            height: 70px;
+            margin: 15px 0px 5px;
+            h3{
+              line-height: 70px;
+              font-weight: bold;
+              font-size: 16px;
+            }
+          }
+          .actions{
             height:160px;
             text-align: center;
             margin-top: 20px;
             p{
               margin-bottom: 20px;
             }
-            .next_btn{
-              line-height: 80px;
-              width: 343px;
-              height: 50px;
-              padding: 15px 130px;
-              text-decoration: none;
+            input{
+              padding: 10px 110px;
+              border-radius: 6px;
               font-size: 15px;
               color: white;
               background-color: red;
-              bottom: 0px;
             }
           }
         }

--- a/app/assets/stylesheets/devise/sessions/_new.scss
+++ b/app/assets/stylesheets/devise/sessions/_new.scss
@@ -42,7 +42,7 @@
       }
     }
     &__contents{
-      height: 300px;
+      height: 380px;
       padding: 40px 16px 40px;
       border-top: 1px solid #f5f5f5;
       &__list{
@@ -60,7 +60,7 @@
           }
           p{
             font-size: 14px;
-            margin-left: 28px;
+            margin: 15px 0px 0px 22px;
           }
           .new_user{
             margin-top: 20px;
@@ -108,7 +108,7 @@
         text-decoration: none;
         font-size: 12px;
         color: #333;
-        padding: 0px 30px;
+        padding: 0px 15px;
       }
       &__logo{
         margin-top: 40px;

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -15,7 +15,7 @@
           = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
             = render "devise/shared/error_messages", resource: resource
             .user_information
-              %h1 ユーザー情報
+              %h1 ● ユーザー情報
               %br/
             .field
               = f.label :ニックネーム, class:"field__label"
@@ -42,7 +42,7 @@
               %span.require 必須
               = f.password_field :password_digest, autocomplete: "new-password", placeholder: "パスワード再入力", class: "field__password"
             .identification
-              %h2 本人確認
+              %h2 ● 本人確認
               %br/
               %ol 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
             .form_group
@@ -65,9 +65,57 @@
               %br/
               .form_birthday__selector
                 = f.date_select :birthday, use_month_numbers: true, start_year: Time.now.year, end_year: (Time.now.year - 10), default: Date.new(Time.now.year,Time.now.month,Time.now.day), class:"a"
-            .move_next
+            .address
+              %h3 ● 商品送付先住所情報
+            .form_group
+              = f.label :送付先氏名（全角）,class:"field__label"
+              %span.require 必須
+              %br/
+              .form_group__input
+                = f.text_field :last_name, autocomplete: "family_name", placeholder:"例)山田", class:"form_group__input__inf"
+                = f.text_field :first_name, autocomplete: "given_name", placeholder:"例)太郎", class:"form_group__input__inf"
+            .form_group
+              = f.label :送付先氏名カナ（全角）,class:"field__label"
+              %span.require 必須
+              %br/
+              .form_group__input
+                = f.text_field :last_name_kana, autocomplete: "on", placeholder:"例)ヤマダ", class:"form_group__input__inf"
+                = f.text_field :first_name_kana, autocomplete: "on", placeholder:"例)タロウ", class:"form_group__input__inf"
+            .field
+              = f.label :郵便番号, class:"field__label"
+              %span.require 必須
+              %br/
+              = f.text_field :postal_code, autocomplete: "postal_code", placeholder: "例)123-4567", class:"field__input"
+              %br/
+            .field
+              = f.label :都道府県, class:"field__label"
+              %span.require 必須
+              %br/
+              = f.text_field :prefecture, autocomplete: "address-level1", placeholder: "例)東京都", class:"field__input"
+              %br/
+            .field
+              = f.label :市区町村, class:"field__label"
+              %span.require 必須
+              %br/
+              = f.text_field :city, autocomplete: "address-level2", placeholder: "渋谷区", class:"field__input"
+              %br/
+            .field
+              = f.label :番地, class:"field__label"
+              %span.require 必須
+              %br/
+              = f.text_field :street, autocomplete: "street-address", placeholder: "道玄坂2丁目23-12", class:"field__input"
+              %br/
+            .field
+              = f.label :マンション名・ビル名・部屋番号, class:"field__label"
+              = f.text_field :apartment, autocomplete: "address-line1", placeholder: "※任意", class:"field__input"
+              %br/
+            .field
+              = f.label :お届け先電話番号, class:"field__label"
+              = f.text_field :phone_number, autocomplete: "off", placeholder: "※任意", class:"field__input"
+              %br/
+            .actions
               %P ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
-              = link_to "登録する","/", class: "next_btn"
+              = f.submit "登録する"
   .drn__footer
     .drn__footer__contents
       = link_to "プライバシーポリシー","/", class: "drn__footer__contents__link"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -91,7 +91,7 @@
               = f.label :都道府県, class:"field__label"
               %span.require 必須
               %br/
-              = f.text_field :prefecture, autocomplete: "address-level1", placeholder: "例)東京都", class:"field__input"
+              = f.text_field :prefecture_id, autocomplete: "address-level1", placeholder: "例)東京都", class:"field__input"
               %br/
             .field
               = f.label :市区町村, class:"field__label"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -12,9 +12,10 @@
       .dsn__main__contents__list
         .dsn__main__contents__list__form
           %h2.login ログイン 
-          %p ※ メールアドレスを入力してください
+          %p ※ メールアドレス / パスワード を入力して下さい
           = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
             = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "field"
+            = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "field"
             .actions
               = f.submit "Log in", class: "login_btn"
   .dsn__footer


### PR DESCRIPTION
What: ユーザー新規登録画面に発送先住所記入欄を追加。ログイン画面にパスワード入力欄を追加。

Why: データベース設計における問題が解決したためユーザー新規登録画面で発送先住所記入欄を設けることが可能になったため追加。ログイン画面の修正は実装におけるタスクの認識が間違っていたため修正。

ログイン画面
　　https://gyazo.com/f1191de4b55ad5f96c573eff663deb62

新規登録画面
　　https://gyazo.com/4b8af6f66eed79b1229b096e118fe587
　　https://gyazo.com/c9681c6261ed94222562a474ff8f2828
　　https://gyazo.com/c0ee2dc44e0eb03251923dcab09da6a0
　　https://gyazo.com/e40d17bc2b1fee1401685000c246496e