### PR TITLE
先行// 新規登録+ログイン機能

### DIFF
--- a/app/assets/stylesheets/devise/sessions/_new.scss
+++ b/app/assets/stylesheets/devise/sessions/_new.scss
@@ -62,7 +62,7 @@
             font-size: 14px;
             margin: 15px 0px 0px 22px;
           }
-          .user{
+          .existing_user{
             margin-top: 20px;
             width: 350px;
             height: 80px;

--- a/app/assets/stylesheets/devise/sessions/_new.scss
+++ b/app/assets/stylesheets/devise/sessions/_new.scss
@@ -62,7 +62,7 @@
             font-size: 14px;
             margin: 15px 0px 0px 22px;
           }
-          .new_user{
+          .user{
             margin-top: 20px;
             width: 350px;
             height: 80px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(resource)
-    new_user_session_path # ログアウト後に遷移するpathを設定
+    new_user_session_path 
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,17 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname,:last_name,:first_name,:last_name_kana,:first_name_kana,:birthday])
+  end
+
+  def after_sign_out_path_for(resource)
+    new_user_session_path # ログアウト後に遷移するpathを設定
+  end
 
   private
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -5,6 +5,10 @@ class Address < ApplicationRecord
   belongs_to :user
 
   with_options presence: true do
+    validates :family_name
+    validates :given_name
+    validates :family_name_kana
+    validates :given_name_kana
     validates :postal_code
     validates :prefecture_id
     validates :city

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -5,10 +5,6 @@ class Address < ApplicationRecord
   belongs_to :user
 
   with_options presence: true do
-    validates :family_name
-    validates :given_name
-    validates :family_name_kana
-    validates :given_name_kana
     validates :postal_code
     validates :prefecture_id
     validates :city

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -31,16 +31,16 @@
             .field
               = f.label :パスワード, class:"field__label"
               %span.require 必須
-              - if @minimum_password_length
-                %em
-                  (#{@minimum_password_length} characters minimum)
-              %br/
-              = f.password_field :encrypted_password, autocomplete: "new-password", placeholder: "7文字以上の半角英数字", class: "field__password"
+              -# - if @minimum_password_length
+              -#   %em
+              -#     (#{@minimum_password_length} characters minimum)
+              -# %br/
+              = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上の半角英数字", class: "field__password"
               %p ※ 英字と数字の両方を含めて設定してください
             .field_confirm
               = f.label :パスワード（確認）, class:"field__label"
               %span.require 必須
-              = f.password_field :password_digest, autocomplete: "new-password", placeholder: "パスワード再入力", class: "field__password"
+              = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード再入力", class: "field__password"
             .identification
               %h2 ● 本人確認
               %br/
@@ -72,15 +72,15 @@
               %span.require 必須
               %br/
               .form_group__input
-                = f.text_field :last_name, autocomplete: "family_name", placeholder:"例)山田", class:"form_group__input__inf"
-                = f.text_field :first_name, autocomplete: "given_name", placeholder:"例)太郎", class:"form_group__input__inf"
+                = f.text_field :family_name, autocomplete: "family_name", placeholder:"例)山田", class:"form_group__input__inf"
+                = f.text_field :given_name, autocomplete: "given_name", placeholder:"例)太郎", class:"form_group__input__inf"
             .form_group
               = f.label :送付先氏名カナ（全角）,class:"field__label"
               %span.require 必須
               %br/
               .form_group__input
-                = f.text_field :last_name_kana, autocomplete: "on", placeholder:"例)ヤマダ", class:"form_group__input__inf"
-                = f.text_field :first_name_kana, autocomplete: "on", placeholder:"例)タロウ", class:"form_group__input__inf"
+                = f.text_field :family_name_kana, autocomplete: "on", placeholder:"例)ヤマダ", class:"form_group__input__inf"
+                = f.text_field :given_name_kana, autocomplete: "on", placeholder:"例)タロウ", class:"form_group__input__inf"
             .field
               = f.label :郵便番号, class:"field__label"
               %span.require 必須

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -13,7 +13,7 @@
         .dsn__main__contents__list__form
           %h2.login ログイン 
           %p ※ メールアドレス / パスワード を入力して下さい
-          = form_with model: @user, url: user_session_path, class: 'existing', local: true do |f|
+          = form_with model: @user, url: user_session_path, class: 'existing_user', local: true do |f|
             = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "field"
             = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "field"
             .actions

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -13,7 +13,7 @@
         .dsn__main__contents__list__form
           %h2.login ログイン 
           %p ※ メールアドレス / パスワード を入力して下さい
-          = form_with model: @user, url: user_session_path, class: 'user', local: true do |f|
+          = form_with model: @user, url: user_session_path, class: 'existing', local: true do |f|
             = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "field"
             = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "field"
             .actions

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -13,7 +13,7 @@
         .dsn__main__contents__list__form
           %h2.login ログイン 
           %p ※ メールアドレス / パスワード を入力して下さい
-          = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
+          = form_with model: @user, url: user_session_path, class: 'user', local: true do |f|
             = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "field"
             = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "field"
             .actions

--- a/app/views/partials/_header.html.haml
+++ b/app/views/partials/_header.html.haml
@@ -50,6 +50,8 @@
         %ul.ii__pcHeader__headerInner__nav__listRight
           %li.ii__pcHeader__headerInner__nav__listRight__item.ii__pcHeader__headerInner__nav__listRight__item--mypage
           = link_to "マイページ", "/users/#{current_user.id}"
+          %li.ii__pcHeader__headerInner__nav__listRight__item.ii__pcHeader__headerInner__nav__listRight__item--logout
+          = link_to "ログアウト", destroy_user_session_path, method: :delete
       - else
         %ul.ii__pcHeader__headerInner__nav__listRight
           %li.ii__pcHeader__headerInner__nav__listRight__item.ii__pcHeader__headerInner__nav__listRight__item--login


### PR DESCRIPTION
what: 他の担当者の実装に必要な新規登録＋ログイン/ ログアウトの機能を先行的に作成。
why: 多機能の実装の進行に影響が出てしまうため。
ユーザー新規登録：
　ユーザー情報の登録と本人確認のみで通過できるようになっている。
　発送先住所情報の登録はが無くても登録できる仕様になっているため後ほど修正する。
  https://gyazo.com/adccef6705b05a62b0de1347e193a97e
ログイン機能：
　正常に動作している。
  https://gyazo.com/541c5c9df54a8b502d6b536cf4d417b3
ログアウト機能：
　仮置きでトップページにログアウトボタンを設置。
　遷移先はログインページに設定。
  https://gyazo.com/f3b039f648d21c338e120bf9d58315a1