### PR TITLE
商品画像複数保存とバリデーション

### DIFF
--- a/app/assets/javascripts/items/image.js
+++ b/app/assets/javascripts/items/image.js
@@ -13,8 +13,8 @@ $(function(){
   const buildFileField = (num)=> {
     const html = `<div data-index="${num}" class="items_new-js-file_group">
                     <input class="items_new-js-file" type="file"
-                    name="item[item_images_attributes][${num}][item_image]"
-                    id="item_images_attributes_${num}_item_image"
+                    name="item[images_attributes][${num}][item_image]"
+                    id="images_attributes_${num}_item_image"
                     style= "display:none;">
                   </div>`;
     return html;

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,20 +12,21 @@ class Item < ApplicationRecord
 
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
-
+  # 画像がないと投稿できないようにするバリデーション
+  validates_presence_of :images 
 
   # helperオプションは出品機能が最低限完了し次第、付与。
   # 今はチームメンバーから一部引き継いでいる状態なので、要相談、一旦バリデーションはコメントアウトする
-  # with_options presence: true do
-  #   validates :name
-  #   validates :price
-  #   validates :discription
-  #   validates :category_id
-  #   validates :condition_id
-  #   validates :burden_id
-  #   validates :prefecture_id
-  #   validates :duration_id
-  # end
+  with_options presence: true do
+    validates :name
+    validates :price
+    validates :discription
+    validates :category_id
+    validates :condition_id
+    validates :burden_id
+    validates :prefecture_id
+    validates :duration_id
+  end
 
   # showアクションのビューで前の商品を呼び出すメソッド
   def previous

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -16,35 +16,6 @@
                 = f.fields_for :images do |image|
                   .items_newt-js-file_group{"data-index" => "#{@item.images.index}"}
                     = image.file_field :item_image, class: 'items_new-js-file', style: "display:none"
-
-      -# .image-wrapper
-      -#   .image-wrapper__label
-      -#     出品画像 
-      -#     %span.image-wrapper__label__tag 
-      -#       必須
-      -#   .imate-wrapper__text 最大5枚までアップロードできます
-      -#   .image-wrapper__image
-      -#     .post__drop__box__container
-      -#       .prev-content
-      -#       .label-content
-      -#         %label{for: "item_images_attributes_0_image", class: "label-box", id: "label-box--0" ,type: "file"}
-      -#           %pre.label-box__text-visible クリックしてファイルをアップロード
-      -#       .hidden-content
-      -#         = f.fields_for :images do |i|
-      -#           - for num in 0..4 do
-      -#             = i.file_field :item_image, class: "hidden-field", name: "item[images_attributes][#{num}][item_image]", id: "item_images_attributes_#{num}_item_image"
-        -# #image-box
-        -#   #previews
-        -#     - if @item.persisted?
-        -#       - @item.images.each_with_index do |image, i|
-        -#         = image_tag image.item_index.url, data: { index: i }, width: "100", height: '100'
-        -#   = f.fields_for :images do |image|
-        -#     .js-file_group{"data-index" => "#{image.index}"}
-        -#       = image.file_field :item_index, class: 'js-file' 
-        -#       %br/
-        -#       %span.js-remove 削除
-
-
         
 
       .in__main__discription


### PR DESCRIPTION
# what
複数画像選択できでも１枚しか保存されないバグを解消。画像を選択しないと保存されないようにimagesにバリデーションを追加
# why
商品出品機能において商品画像の複数投稿は必須であるため。


### キャプチャ
https://gyazo.com/deffb56655c41f7cd11b2b82638dcf0f