### PR TITLE
編集ページエラーメッセージ表示設定

### DIFF
--- a/app/assets/stylesheets/devise/registrations/_create_address.scss
+++ b/app/assets/stylesheets/devise/registrations/_create_address.scss
@@ -60,7 +60,7 @@
             border-radius: 6px;
             font-size: 15px;
             color: white;
-            background-color: red;
+            background-color: #3CCACE;;
           }
         }
       }

--- a/app/assets/stylesheets/devise/registrations/_new.scss
+++ b/app/assets/stylesheets/devise/registrations/_new.scss
@@ -89,7 +89,7 @@
               border-radius: 2px;
               font-weight: 100;
               color:white;
-              background-color: red;
+              background-color: #3CCACE;;
               font-size: 12px;
             }
             &__input{
@@ -129,7 +129,7 @@
               border-radius: 2px;
               font-weight: 100;
               color:white;
-              background-color: red;
+              background-color: #3CCACE;;
               font-size: 12px;
             }
           }
@@ -152,7 +152,7 @@
               border-radius: 2px;
               font-weight: 100;
               color:white;
-              background-color: red;
+              background-color: #3CCACE;;
               font-size: 12px;
             }
             &__input{
@@ -181,7 +181,7 @@
               border-radius: 2px;
               font-weight: 100;
               color:white;
-              background-color: red;
+              background-color: #3CCACE;;
               font-size: 12px;
             }
             .form_birthday__selector{
@@ -218,7 +218,7 @@
               border-radius: 6px;
               font-size: 15px;
               color: white;
-              background-color: red;
+              background-color: #3CCACE;;
             }
           }
         }

--- a/app/assets/stylesheets/devise/registrations/_new_address.scss
+++ b/app/assets/stylesheets/devise/registrations/_new_address.scss
@@ -87,7 +87,7 @@
                 border-radius: 2px;
                 font-weight: 100;
                 color:white;
-                background-color: red;
+                background-color: #3CCACE;;
                 font-size: 12px;
               }
               &__input{
@@ -135,7 +135,7 @@
                 border-radius: 6px;
                 font-size: 15px;
                 color: white;
-                background-color: red;
+                background-color:  #3CCACE;
               }
             }
           }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -131,9 +131,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-
-      render :"new"
-
+      render :new
     end
   end
 
@@ -176,15 +174,39 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
+    @item = Item.find(params[:id])
     
-    if item.update(item_params)
+    grandchild_category = @item.category
+    child_category = grandchild_category.parent
+
+    @category_parent_array = ["選択してください"]
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
+    end
+
+    @category_children_array = []
+    Category.where(ancestry: child_category.ancestry).each do |children|
+      @category_children_array << children
+    end
+
+    @category_grandchildren_array = []
+    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
+      @category_grandchildren_array << grandchildren
+    end
+
+    if @item.update(item_params)
       redirect_to root_path
     else
       render :edit
     end
   end
 
+  # def create
+  #   @item = Item.new(item_params)
+  #   @category_parent_array = ["選択してください"]  
+  #   Category.where(ancestry: nil).each do |parent|
+  #     @category_parent_array << parent.name
+  #   end
 
 
   private

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -18,5 +18,5 @@
       = link_to "FURIMA利用規約","/", class: "drc__footer__contents__link"
       = link_to "特定商取引に関する表記","/", class: "drc__footer__contents__link"
       .dsn__footer__contents__logo
-        = link_to image_tag("material/logo/logo.png", size: "130x50"), "/", class: "drc__footer__contents__logo__btn"
+        = link_to image_tag("material/logo/logo.png", size: "185x50"), "/", class: "drc__footer__contents__logo__btn"
         %p © furima, Inc.

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -74,5 +74,5 @@
       = link_to "FURIMA利用規約","/", class: "drn__footer__contents__link"
       = link_to "特定商取引に関する表記","/", class: "drn__footer__contents__link"
       .drn__footer__contents__logo
-        = link_to image_tag("material/logo/logo.png", size: "130x50"), "/", class: "drn__footer__contents__logo__btn"
+        = link_to image_tag("material/logo/logo.png", size: "185x50"), "/", class: "drn__footer__contents__logo__btn"
         %p © furima, Inc.

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -73,6 +73,6 @@
       = link_to "FURIMA利用規約","/", class: "drna__footer__contents__link"
       = link_to "特定商取引に関する表記","/", class: "drna__footer__contents__link"
       .drn__footer__contents__logo
-        = link_to image_tag("material/logo/logo.png", size: "130x50"), "/", class: "drna__footer__contents__logo__btn"
+        = link_to image_tag("material/logo/logo.png", size: "185x50"), "/", class: "drna__footer__contents__logo__btn"
         %p © furima, Inc.
   

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -24,5 +24,5 @@
       = link_to "FURIMA利用規約","/", class: "dsn__footer__contents__link"
       = link_to "特定商取引に関する表記","/", class: "dsn__footer__contents__link"
       .dsn__footer__contents__logo
-        = link_to image_tag("material/logo/logo.png", size: "130x50"), "/", class: "dsn__footer__contents__logo__btn"
+        = link_to image_tag("material/logo/logo.png", size: "185x50"), "/", class: "dsn__footer__contents__logo__btn"
         %p © furima, Inc.

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -2,6 +2,7 @@
   = render partial: "partials/header"
   .in__main
     = form_with(model: @item, local:true) do |f|
+      = render 'layouts/error_messages', model: f.object
       .items_new-newimage
         .items_new-product__headline
           .items_new-product__headline--title 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -3,7 +3,7 @@
   .in__main
 
     = form_with(model: @item, local:true) do |f|
-      = render 'layouts/error_messages', model: f.object 
+      = render 'layouts/error_messages', model: f.object
 
       .items_new-newimage
         .items_new-product__headline

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -229,6 +229,7 @@ ja:
         street: 番地 
     attributes:
       item: 
+        images: 画像
         name: 商品名
         price: 販売価格
         discription: 商品の説明


### PR DESCRIPTION
What: 編集ページ上でのエラーメッセージの実装。
　　　ユーザー登録、出品ページと同様の仕様となっている。
　　　また、追加でユーザー新規登録機能のビューの微調整。配色をフリマのロゴマークの色に統一。
Why: 単体テストの際、期待値にエラー文の表示を使用するため。
          ユーザー新規登録/ログインページの配色の未修正であったためそれを統一するため。
　　　footer部分のlogoサイズ修正
編集ページのエラーメッセージ
　https://gyazo.com/95ef32a698d0bc0f987354d392714c20
ユーザー新規登録ページ/ログイン画面の配色調整
　https://gyazo.com/f1ba317951645aa11ca185ee479b6679
　https://gyazo.com/30015f2c4d01587814fff9b260fae836
　https://gyazo.com/e025426cf65a2a74a2069b4e667215c9
   https://gyazo.com/9449499f8fb6c93bee490d4ead70953c